### PR TITLE
add THROTTLED and retry_after_seconds to AssignProfileResponse

### DIFF
--- a/dep/schemas/AssignProfileResponse.json
+++ b/dep/schemas/AssignProfileResponse.json
@@ -16,8 +16,8 @@
       "type": "string"
     },
     "retry_after_seconds": {
-      "type": "integer",
-      "description": "This key is only returned with X-Server-Protocol-Version 10 and later. It indicates how long to wait before retrying assignment for the THROTTLED devices."
+      "description": "This key is only returned with X-Server-Protocol-Version 10 and later. It indicates how long to wait before retrying assignment for the THROTTLED devices.",
+      "type": "integer"
     }
   }
 }

--- a/dep/schemas/AssignProfileResponse.json
+++ b/dep/schemas/AssignProfileResponse.json
@@ -8,11 +8,16 @@
     "devices": {
       "type": "object",
       "additionalProperties": {
-        "enum": [ "SUCCESS", "NOT_ACCESSIBLE", "FAILED" ]
+        "description": "THROTTLED is returned with X-Server-Protocol-Version 9 and later when the server is throttling the request.",
+        "enum": [ "SUCCESS", "NOT_ACCESSIBLE", "FAILED", "THROTTLED" ]
       }
     },
     "profile_uuid": {
       "type": "string"
+    },
+    "retry_after_seconds": {
+      "type": "integer",
+      "description": "This key is only returned with X-Server-Protocol-Version 10 and later. It indicates how long to wait before retrying assignment for the THROTTLED devices."
     }
   }
 }


### PR DESCRIPTION
This PR adds the `THROTTLED` status which is returned with `X-Server-Protocol-Version 9` and later, as well as the `retry_after_seconds` which is returned with `X-Server-Protocol-Version 10` and later.

Based on docs: https://developer.apple.com/documentation/devicemanagement/assign-profile#Throttling

I know the `description` field inside the `additionalProperties` does not actually generate anything, but I have a [PR](https://github.com/omissis/go-jsonschema/pull/598) up for that at the generator, that way it will generate the description as a comment on the enum type declaration.